### PR TITLE
Upgrade react-navigation version 3 to 4

### DIFF
--- a/Examples/show-me-the-coin/App.js
+++ b/Examples/show-me-the-coin/App.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { View, Text } from 'react-native'
-import { createStackNavigator, createAppContainer } from 'react-navigation';
+import { createAppContainer } from 'react-navigation';
+import { createStackNavigator } from 'react-navigation-stack';
 
 import Home from './screens/Home'
 import Youtube from './screens/Youtube';
@@ -20,9 +21,9 @@ const MainStack = createStackNavigator({
     navigationOptions: ({navigation}) => {
       return {
         headerTitle: (
-          <Header 
-            title={'Show Me The Coin'} 
-            subtitle={navigation.getParam('refreshDate', '-')} 
+          <Header
+            title={'Show Me The Coin'}
+            subtitle={navigation.getParam('refreshDate', '-')}
           />
         ),
         headerStyle: {

--- a/Examples/show-me-the-coin/package.json
+++ b/Examples/show-me-the-coin/package.json
@@ -14,7 +14,8 @@
     "react-native-gesture-handler": "~1.3.0",
     "react-native-reanimated": "~1.1.0",
     "react-native-webview": "^6.9.0",
-    "react-navigation": "^3.11.1"
+    "react-navigation": "^4.0.5",
+    "react-navigation-stack": "^1.7.3"
   },
   "devDependencies": {
     "babel-preset-expo": "^5.0.0"

--- a/README.md
+++ b/README.md
@@ -1092,7 +1092,7 @@ screens/CoinView.js
 We will use one of the most popular router libraries. [react-navigation](https://github.com/react-navigation/react-navigation)
 
 ```js
-yarn add react-navigation@3.11.1
+yarn add react-navigation@4.0.5
 expo install react-native-gesture-handler
 expo install react-native-reanimated
 ```
@@ -1118,7 +1118,8 @@ App.js
 ```js
 import React from 'react'
 import { View, Text } from 'react-native'
-import { createStackNavigator, createAppContainer } from 'react-navigation';
+import { createAppContainer } from 'react-navigation';
+import { createStackNavigator } from 'react-navigation-stack';
 
 import Home from './screens/Home'
 


### PR DESCRIPTION
React-navigation's stable version is v4. ([React-navigation doc](https://reactnavigation.org/en/versions.html))

But react-navigation version in the tutorial(show me the coin) is v3.

So I upgrade it and fix README.md.