### PR TITLE
Delete .expo in tutorial example

### DIFF
--- a/Examples/StateManagement/SetStateBasic/.expo/packager-info.json
+++ b/Examples/StateManagement/SetStateBasic/.expo/packager-info.json
@@ -1,3 +1,0 @@
-{
-  "devToolsPort": 19002
-}

--- a/Examples/StateManagement/SetStateBasic/.expo/settings.json
+++ b/Examples/StateManagement/SetStateBasic/.expo/settings.json
@@ -1,8 +1,0 @@
-{
-  "hostType": "lan",
-  "lanType": "ip",
-  "dev": true,
-  "minify": false,
-  "urlRandomness": null,
-  "https": false
-}


### PR DESCRIPTION
## Fix 
- Eliminate .expo file in team-state tutorial

## Changes
- .expo deleted
