### PR TITLE
Add references of debugging docs

### DIFF
--- a/docs/Debugging/Android-Debugging-kr.md
+++ b/docs/Debugging/Android-Debugging-kr.md
@@ -298,3 +298,10 @@ Firebase crash reporting은 앱의 오류에 대한 자세한 보고서를 생�
 
 Firebase 종속성을 build.gradle 파일에 추가하기만 하면 모든 사용자로 부터 충돌 보고서가 수신되기 시작합니다. 자세한 내용은 [Firebase crash reporting](https://firebase.google.com/docs/crash/?hl=ko)을 참조해야 합니다.
 
+## 출처
+
+- [스택 추적 분석하기](https://developer.android.com/studio/debug/stacktraces)
+- [완벽한 픽셀!](https://developer.android.com/studio/debug/pixel-perfect)
+- [스크린 샷 찍기](https://developer.android.com/studio/debug/am-screenshot)
+- [비디오 녹화하기](https://developer.android.com/studio/debug/am-video)
+- [버그 보고서 캡쳐 및 읽기](https://developer.android.com/studio/debug/bug-report)

--- a/docs/Debugging/Android-Debugging.md
+++ b/docs/Debugging/Android-Debugging.md
@@ -291,3 +291,10 @@ Firebase crash reporting creates detailed reports of the errors in your app. Err
 
 You'll start receiving crash reports from any user by simply adding the Firebase dependencies to your `build.gradle` file. For more information, see [Firebase crash reporting](https://firebase.google.com/docs/crash/?hl=ko).
 
+## References
+
+- [Analyze a stack trace](https://developer.android.com/studio/debug/stacktraces)
+- [Pixel Perfect!](https://developer.android.com/studio/debug/pixel-perfect)
+- [Take a screenshot](https://developer.android.com/studio/debug/am-screenshot)
+- [Record a video](https://developer.android.com/studio/debug/am-video)
+- [Capture and read bug reports](https://developer.android.com/studio/debug/bug-report)

--- a/docs/Debugging/iOS-Debugging-kr.md
+++ b/docs/Debugging/iOS-Debugging-kr.md
@@ -184,3 +184,12 @@ Xcode Behaviors 환경 설정에서 작업 과정에서 중요한 작업들을 �
 사용자 지정 동작에 키보드 동작을 할당하려면, Xcode > Preferences 를 선택하고 Key Bingings를 선택하면 됩니다. Key Bindings preferences 화면에서 원하는 사용자 지정 동작을 찾기 위해 Customized 탭을 선택하세요. 텍스트 필드에서 텍스트 필드와 연결하길 원하는 키를 누르고 동작을 마무리하기위해 텍스트 필드 바깥을 선택하세요.
 
 breakpoints와 breakpoint의 타입들에 대해 더 자세히 알려면 [Xcode Help](https://help.apple.com/xcode)를 참고하세요.
+
+## 출처
+
+1. [디버거 사용하기](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/UsingtheDebugger.html#//apple_ref/doc/uid/TP40010215-CH57-SW1l)
+2. [뷰 계층 검사하기](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/ExaminingtheViewHierarchy.html#//apple_ref/doc/uid/TP40010215-CH58-SW1)
+3. [시스템 임팩트 검사하기](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/ExaminingSystemImpact.html#//apple_ref/doc/uid/TP40010215-CH59-SW1)
+4. [성능 측정하기](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/MeasuringPerformance.html#//apple_ref/doc/uid/TP40010215-CH60-SW1)
+5. [시뮬레이터에 관련된 문제들](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/SimulatingProblems.html#//apple_ref/doc/uid/TP40010215-CH61-SW1)
+6. [작업 과정 커스터마이징하기](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/CustomizingYourWorkflow.html#//apple_ref/doc/uid/TP40010215-CH62-SW1)

--- a/docs/Debugging/iOS-Debugging.md
+++ b/docs/Debugging/iOS-Debugging.md
@@ -185,3 +185,12 @@ You can design custom behaviors that are triggered by menu items or their keyboa
 To assign a keyboard equivalent to a custom behavior, choose Xcode > Preferences and click Key Bindings. In the Key Bindings preferences pane, select the Customized tab to find the custom behavior you want. In the text field, enter the keys you want to use for the key binding in the text field, and click outside the text field to complete the operation.
 
 For more detail on types of breakpoints and breakpoint actions, see [Xcode Help](https://help.apple.com/xcode).
+
+## References
+
+1. [Using the Debugger](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/UsingtheDebugger.html#//apple_ref/doc/uid/TP40010215-CH57-SW1l)
+2. [Examining the View Hierarchy](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/ExaminingtheViewHierarchy.html#//apple_ref/doc/uid/TP40010215-CH58-SW1)
+3. [Examining System Impact](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/ExaminingSystemImpact.html#//apple_ref/doc/uid/TP40010215-CH59-SW1)
+4. [Measuring Performance](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/MeasuringPerformance.html#//apple_ref/doc/uid/TP40010215-CH60-SW1)
+5. [Simulating Problems](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/SimulatingProblems.html#//apple_ref/doc/uid/TP40010215-CH61-SW1)
+6. [Customizing Your Workflow](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/CustomizingYourWorkflow.html#//apple_ref/doc/uid/TP40010215-CH62-SW1)


### PR DESCRIPTION
## Fix #
- Need to add references of debugging docs.

## Changes
- Add reference on the `iOS-Debugging` docs
- Add reference on the `Android-Debugging` docs

## How Verified
N/A

### Notes
N/A

### References
- [Android Studio](https://developer.android.com/studio/debug)
- [Xcode](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/UsingtheDebugger.html#//apple_ref/doc/uid/TP40010215-CH57-SW1)
